### PR TITLE
Fix link to project guidelines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Here you'll find:
   * [CheckStyle Configuration](/Code_Quality/checkstyle)  
   * [FindBugs Configuration](/Code_Quality/findbugs)  
   * [PMD Configuration](/Code_Quality/pmd) 
-2. [Project Guidelines] (/project_style_guidelines.md) 
+2. [Project Guidelines](project_style_guidelines.md) 
 
 ##Licence
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-#Android Guidelines
--------------------
+# Android Guidelines
 
 Welcome to the Android Guidelines repo 👋 
 
@@ -8,12 +7,12 @@ This repository is used to house all of our project guidelines for the Buffer Ap
 Here you'll find:
 
 1. [Code Quality](/Code_Quality)  
-  * [CheckStyle Configuration](/Code_Quality/checkstyle)  
-  * [FindBugs Configuration](/Code_Quality/findbugs)  
-  * [PMD Configuration](/Code_Quality/pmd) 
+   * [CheckStyle Configuration](/Code_Quality/checkstyle)  
+   * [FindBugs Configuration](/Code_Quality/findbugs)  
+   * [PMD Configuration](/Code_Quality/pmd) 
 2. [Project Guidelines](project_style_guidelines.md) 
 
-##Licence
+## Licence
 
 ```
 Copyright 2016 Buffer, Inc.


### PR DESCRIPTION
Just a typo in the markdown meant a broken link :)